### PR TITLE
Add Apache 2.0 licence

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,12 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: LumoSQL
+Upstream-Contact: The LumoSQL Authors
+Source: https://github.com/LumoSQL/LumoSQL
+
+Files: .gitignore
+Copyright: 2019 The LumoSQL Authors
+License: Apache-2.0
+
+Files: AUTHORS
+Copyright: 2019 The LumoSQL Authors
+License: Apache-2.0

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,5 @@
+Authors
+=======
+
+Dan Shearer
+Keith Maxwell

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,208 @@
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/ TERMS AND CONDITIONS FOR USE, REPRODUCTION,
+AND DISTRIBUTION
+
+   1. Definitions.
+
+      
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution
+as defined by Sections 1 through 9 of this document.
+
+      
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+      
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct
+or indirect, to cause the direction or management of such entity, whether
+by contract or otherwise, or (ii) ownership of fifty percent (50%) or more
+of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+      
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions
+granted by this License.
+
+      
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+      
+
+"Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
+
+      
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that
+is included in or attached to the work (an example is provided in the Appendix
+below).
+
+      
+
+"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative
+Works shall not include works that remain separable from, or merely link (or
+bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+      
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative
+Works thereof, that is intentionally submitted to Licensor for inclusion in
+the Work by the copyright owner or by an individual or Legal Entity authorized
+to submit on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication
+sent to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor
+for the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+      
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently incorporated
+within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable copyright license to reproduce, prepare
+Derivative Works of, publicly display, publicly perform, sublicense, and distribute
+the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their Contribution(s)
+alone or by combination of their Contribution(s) with the Work to which such
+Contribution(s) was submitted. If You institute patent litigation against
+any entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that the Work or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses granted to You
+under this License for that Work shall terminate as of the date such litigation
+is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and
+in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy
+of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that
+You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source
+form of the Work, excluding those notices that do not pertain to any part
+of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy
+of the attribution notices contained within such NOTICE file, excluding those
+notices that do not pertain to any part of the Derivative Works, in at least
+one of the following places: within a NOTICE text file distributed as part
+of the Derivative Works; within the Source form or documentation, if provided
+along with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works
+that You distribute, alongside or as an addendum to the NOTICE text from the
+Work, provided that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction,
+or distribution of Your modifications, or for any such Derivative Works as
+a whole, provided Your use, reproduction, and distribution of the Work otherwise
+complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without
+any additional terms or conditions. Notwithstanding the above, nothing herein
+shall supersede or modify the terms of any separate license agreement you
+may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to
+in writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR
+A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness
+of using or redistributing the Work and assume any risks associated with Your
+exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether
+in tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to
+in writing, shall any Contributor be liable to You for damages, including
+any direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability
+to use the Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses), even if such Contributor has been advised of the possibility
+of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work
+or Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such obligations,
+You may act only on Your own behalf and on Your sole responsibility, not on
+behalf of any other Contributor, and only if You agree to indemnify, defend,
+and hold each Contributor harmless for any liability incurred by, or claims
+asserted against, such Contributor by reason of your accepting any such warranty
+or additional liability. END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own identifying
+information. (Don't include the brackets!) The text should be enclosed in
+the appropriate comment syntax for the file format. We also recommend that
+a file or class name and description of purpose be included on the same "printed
+page" as the copyright notice for easier identification within third-party
+archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,22 @@
+# Copyright 2019 The LumoSQL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2019 The LumoSQL Authors
+#
+# /Makefile
+#
 bin: bld-SQLite-3.30.1 bld-LMDB_0.9.16
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-bin: bld-sqlite-3.30.1 bld-LMDB_0.9.16
+bin: bld-SQLite-3.30.1 bld-LMDB_0.9.16
 
 clean:
 	rm -rf bld-* version.txt

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ clean:
 	rm -rf bld-* version.txt
 
 src-sqlite:
-	git clone git@github.com:sqlite/sqlite.git sqlite.git
+	git clone https://github.com/sqlite/sqlite.git sqlite.git
 
 src-%:
 	# git@github.com:LMDB/sqlightning.git is an alternative to .

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,14 @@ bin: bld-SQLite-3.30.1 bld-LMDB_0.9.16
 clean:
 	rm -rf bld-* version.txt
 
+# Without constraints the clone below will result in 20K commits and a .git
+# directory of 112M; restricting to a single branch and history from the day
+# before first relevant release results in <10K commits and half the disk
+# space. We use the release branch as it may not currently be merged into
+# master.
 src-sqlite:
-	git clone https://github.com/sqlite/sqlite.git src-sqlite
+	git clone --shallow-since 2013-05-19 --branch release \
+		https://github.com/sqlite/sqlite.git src-sqlite
 
 src-%:
 	# git@github.com:LMDB/sqlightning.git is an alternative to .

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ clean:
 	rm -rf bld-* version.txt
 
 src-sqlite:
-	git clone https://github.com/sqlite/sqlite.git sqlite.git
+	git clone https://github.com/sqlite/sqlite.git src-sqlite
 
 src-%:
 	# git@github.com:LMDB/sqlightning.git is an alternative to .

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ bld-SQLite-%: src-sqlite
 bld-LMDB_%: src-lmdb src-mdb
 	git -C src-lmdb checkout LMDB_$*
 	rm -rf $@ && mkdir $@
+	cp LICENSES/Apache-2.0.txt $@/LICENSE
 	cd $@ && ../src-mdb/configure \
 		CFLAGS="-I../src-lmdb/libraries/liblmdb" && cd ..
 	make -C $@ sqlite3.h

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2019 The LumoSQL Authors -->
+
 # LumoSQL
 
 ## About LumoSQL

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ sudo dnf install --assumeyes \
 
 To build either (a) specific versions of SQLite or (b) sqlightning using
 different versions of LMDB, use commands like those below changing the version
-numbers to suit. A list of tested version numbers is in the table below.
+numbers to suit. A list of tested version numbers is in the table
+[below](#which-lmdb-version).
 
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ nevertheless useful and valid:
 git diff orig:tool/speedtest.tcl benchmarking:tool/speedtest.tcl
 ```
 
+Other branches typically begin with `feat/` and represent work in progress for
+the above.
+
 # Compiling SQLite and sqlightning
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ different versions of LMDB, use commands like those below changing the version
 numbers to suit. A list of tested version numbers is in the table
 [below](#which-lmdb-version).
 
-
 ```sh
 make bld-SQLite-3.7.17
 make bld-LMDB_0.9.9
@@ -168,18 +167,6 @@ for name in SQLite-3.30.1 SQLite-3.7.17 ; do
   done ;
 done
 ```
-
-# References
-
-- The
-  [Fedora Spec file for "sqlite3"](https://apps.fedoraproject.org/packages/sqlite/sources/)
-  lists dependencies.
-- The [documentation](https://sqlite.org/whynotgit.html#getthecode) linking to
-  the [official SQLite GitHub mirror](https://github.com/sqlite/sqlite)
-- ["sqlightning" repository](https://github.com/LMDB/sqlightning)
-- Early benchmarking by Howard Chu of <https://pastebin.com/B5SfEieL> of 3.7.17
-- Benchmarking
-  <https://github.com/google/leveldb/blob/master/benchmarks/db_bench_sqlite3.cc>
 
 # Which LMDB version?
 
@@ -235,3 +222,15 @@ reported by <code>git diff --shortstat</code>.</dd>
 
 A **?** means that this has not been tested, and a **-** means that it is not
 applicable at present.
+
+# References
+
+- The
+  [Fedora Spec file for "sqlite3"](https://apps.fedoraproject.org/packages/sqlite/sources/)
+  lists dependencies.
+- The [documentation](https://sqlite.org/whynotgit.html#getthecode) linking to
+  the [official SQLite GitHub mirror](https://github.com/sqlite/sqlite)
+- ["sqlightning" repository](https://github.com/LMDB/sqlightning)
+- Early benchmarking by Howard Chu of <https://pastebin.com/B5SfEieL> of 3.7.17
+- Benchmarking
+  <https://github.com/google/leveldb/blob/master/benchmarks/db_bench_sqlite3.cc>

--- a/README.md
+++ b/README.md
@@ -2,43 +2,57 @@
 
 ## About LumoSQL
 
-LumoSQL is a combination of two embedded data storage C language libraries: [SQLite](https://sqlite.org) and [LMDB](https://github.com/LMDB/lmdb).
-LumoSQL is an updated version of Howard Chu's 2013 [proof of concept](https://github.com/LMDB/sqlightning) combining the codebases. Howard's LMDB
-library has become ubiquitous on the basis of performance and reliability, so the 2013 claims of it greatly increasing the performance of SQLite 
-seem credible. D Richard Hipp's SQLite is relied on by many millions of people on a daily basis (every Android and Firefox user, as just two projects
-of the thousands that use SQLite) so an improved version of SQLite would benefit billions of people.
+LumoSQL is a combination of two embedded data storage C language libraries:
+[SQLite](https://sqlite.org) and [LMDB](https://github.com/LMDB/lmdb). LumoSQL
+is an updated version of Howard Chu's 2013
+[proof of concept](https://github.com/LMDB/sqlightning) combining the codebases.
+Howard's LMDB library has become ubiquitous on the basis of performance and
+reliability, so the 2013 claims of it greatly increasing the performance of
+SQLite seem credible. D Richard Hipp's SQLite is relied on by many millions of
+people on a daily basis (every Android and Firefox user, as just two projects of
+the thousands that use SQLite) so an improved version of SQLite would benefit
+billions of people.
 
-The original code changes btree.c in SQLite 3.7.17 to use LMDB 0.9.9 . It takes some work to replicate the original results because 
-not only has much changed since, but as a proof of concept there was no project established to package code or make it accessible. 
-LumoSQL revives the original code and shows how it is still relevant in 2019. The premise seems sound.
+The original code changes btree.c in SQLite 3.7.17 to use LMDB 0.9.9 . It takes
+some work to replicate the original results because not only has much changed
+since, but as a proof of concept there was no project established to package
+code or make it accessible. LumoSQL revives the original code and shows how it
+is still relevant in 2019. The premise seems sound.
 
 ## About the LumoSQL Project
 
-LumoSQL was started in December 2019 by Dan Shearer, who did the original source tree archeology. Keith Maxwell did the detailed initial work of
-integration, test and verification to produce the Makefile tool. 
+LumoSQL was started in December 2019 by Dan Shearer, who did the original source
+tree archeology. Keith Maxwell did the detailed initial work of integration,
+test and verification to produce the Makefile tool.
 
-The goal of the LumoSQL Project is to create and maintain an improved version of SQLite.
+The goal of the LumoSQL Project is to create and maintain an improved version of
+SQLite.
 
 ## The LumoSQL Makefile tool
 
 LumoSQL provides a Makefile which:
 
-* Re-creates the 2013 proof of concept tree
-* Creates new trees using updated code until the 2013 work starts breaking
-* Allows the 2013 speedtests to be easily replicated on the original and new combined codebases
-* Allows a testing matrix of versions and results
+- Re-creates the 2013 proof of concept tree
+- Creates new trees using updated code until the 2013 work starts breaking
+- Allows the 2013 speedtests to be easily replicated on the original and new
+  combined codebases
+- Allows a testing matrix of versions and results
 
 In the process, we noticed things that need to be fixed:
 
-* Regressions. Some SQLite functionality doesn't work out of the box with the 2013 code, even some basic things like ".schema"
-* Test suite. Even the speedtest portion of the SQLite test suite only partly works. 
-* Close coupling in SQLite. Higher levels of SQLite makes assumptions about how the btree code is implemented, eg knowledge about page sizes.
-* Close coupling in the port. eg the 2013 btree.c #includes LMDB's mdb.c (not mdb.h) and directly modifies the internal LMDB struct  MDB_page.
-* Bitrot. The upstream trees stopped working together in 2015.
+- Regressions. Some SQLite functionality doesn't work out of the box with the
+  2013 code, even some basic things like ".schema"
+- Test suite. Even the speedtest portion of the SQLite test suite only partly
+  works.
+- Close coupling in SQLite. Higher levels of SQLite makes assumptions about how
+  the btree code is implemented, eg knowledge about page sizes.
+- Close coupling in the port. eg the 2013 btree.c #includes LMDB's mdb.c (not
+  mdb.h) and directly modifies the internal LMDB struct MDB_page.
+- Bitrot. The upstream trees stopped working together in 2015.
 
-- Regressions, test failures, opportunities and more are tracked as
+* Regressions, test failures, opportunities and more are tracked as
   [issues](https://github.com/LumoSQL/LumoSQL/issues)
-- Short term planning and progress reporting is tracked on a
+* Short term planning and progress reporting is tracked on a
   [project board](https://github.com/LumoSQL/LumoSQL/projects)
 
 ## Branches
@@ -70,8 +84,9 @@ In the process, we noticed things that need to be fixed:
 <dd>unmodified SQLite 3.7.17, against which the 2013 changes were made. </dd>
 </dl>
 
-The benchmarking branch includes the 2013 sqlightning's cut down version of SQLite's `tools/speedtest.tcl` . 
-It has been cut down to remove tests that did not pass with the new code but is nevertheless useful and valid:
+The benchmarking branch includes the 2013 sqlightning's cut down version of
+SQLite's `tools/speedtest.tcl` . It has been cut down to remove tests that did
+not pass with the new code but is nevertheless useful and valid:
 
 ```sh
 git diff orig:tool/speedtest.tcl benchmarking:tool/speedtest.tcl
@@ -97,41 +112,43 @@ created:
 
 ## Build environment
 
-On Ubuntu 18.0.4 LTS, and on any reasonably recent Debian or Ubuntu-derived distribution, you need only:
+On Ubuntu 18.0.4 LTS, and on any reasonably recent Debian or Ubuntu-derived
+distribution, you need only:
 
-   ```sh
-   sudo apt install build-essential
-   sudo apt build-dep sqlite3
-   ```
+```sh
+sudo apt install build-essential
+sudo apt build-dep sqlite3
+```
 
 ( build-dep requires deb-src lines uncommented in /etc/apt/sources.list .)
 
 On Fedora 30, and on any reasonably recent Fedora-derived distribution:
 
-   ```sh
-   sudo dnf install --assumeyes \
-   make gcc ncurses-devel readline-devel glibc-devel autoconf tcl-devel
-   ```
+```sh
+sudo dnf install --assumeyes \
+make gcc ncurses-devel readline-devel glibc-devel autoconf tcl-devel
+```
 
 ## Using the Makefile tool
 
 To build either (a) specific versions of SQLite or (b) sqlightning using
 different versions of LMDB, use commands like those below:
 
-   ```sh
-   make bld-SQLite-3.7.17
-   make bld-LMDB_0.9.9
-   ```
+```sh
+make bld-SQLite-3.7.17
+make bld-LMDB_0.9.9
+```
 
-changing the version numbers to suit. A list of tested version numbers is in the table
-below. 
-
+changing the version numbers to suit. A list of tested version numbers is in the
+table below.
 
 # Speed tests / benchmarking
 
-To benchmark a single binary takes approximately 4 minutes to complete depending on hardware.
+To benchmark a single binary takes approximately 4 minutes to complete depending
+on hardware.
 
-The instructions in this section explain how to benchmark four different versions:
+The instructions in this section explain how to benchmark four different
+versions:
 
 | V.  | SQLite | LMDB   | Repository  | Name          |
 | --- | ------ | ------ | ----------- | ------------- |

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ sudo dnf install --assumeyes \
 
 ## Using the Makefile tool
 
+Start with a clone of this repository as the current directory. The Makefile
+build tool uses this `benchmarking` branch and the `mdb` branch.
+
 To build either (a) specific versions of SQLite or (b) sqlightning using
 different versions of LMDB, use commands like those below changing the version
 numbers to suit. A list of tested version numbers is in the table

--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ people on a daily basis (every Android and Firefox user, as just two projects of
 the thousands that use SQLite) so an improved version of SQLite would benefit
 billions of people.
 
-The original code changes btree.c in SQLite 3.7.17 to use LMDB 0.9.9 . It takes
-some work to replicate the original results because not only has much changed
-since, but as a proof of concept there was no project established to package
-code or make it accessible. LumoSQL revives the original code and shows how it
-is still relevant in 2019. The premise seems sound.
+The original code changes `btree.c` in SQLite 3.7.17 to use LMDB 0.9.9 . It
+takes some work to replicate the original results because not only has much
+changed since, but as a proof of concept there was no project established to
+package code or make it accessible. LumoSQL revives the original code and shows
+how it is still relevant in 2019. The premise seems sound.
 
 ## About the LumoSQL Project
 
 LumoSQL was started in December 2019 by Dan Shearer, who did the original source
-tree archeology. Keith Maxwell did the detailed initial work of integration,
+tree archaeology. Keith Maxwell did the detailed initial work of integration,
 test and verification to produce the Makefile tool.
 
 The goal of the LumoSQL Project is to create and maintain an improved version of
@@ -34,7 +34,7 @@ LumoSQL provides a Makefile which:
 
 - Re-creates the 2013 proof of concept tree
 - Creates new trees using updated code until the 2013 work starts breaking
-- Allows the 2013 speedtests to be easily replicated on the original and new
+- Allows the 2013 speed tests to be easily replicated on the original and new
   combined codebases
 - Allows a testing matrix of versions and results
 
@@ -42,13 +42,13 @@ In the process, we noticed things that need to be fixed:
 
 - Regressions. Some SQLite functionality doesn't work out of the box with the
   2013 code, even some basic things like ".schema"
-- Test suite. Even the speedtest portion of the SQLite test suite only partly
+- Test suite. Even the speed test portion of the SQLite test suite only partly
   works.
 - Close coupling in SQLite. Higher levels of SQLite makes assumptions about how
-  the btree code is implemented, eg knowledge about page sizes.
-- Close coupling in the port. eg the 2013 btree.c #includes LMDB's mdb.c (not
-  mdb.h) and directly modifies the internal LMDB struct MDB_page.
-- Bitrot. The upstream trees stopped working together in 2015.
+  the btree code is implemented, e.g. knowledge about page sizes.
+- Close coupling in the port, e.g. the 2013 `btree.c` `#includes` LMDB's `mdb.c`
+  (not `mdb.h`) and directly modifies the internal LMDB struct `MDB_page`.
+- Bit-rot. The upstream trees stopped working together in 2015.
 
 * Regressions, test failures, opportunities and more are tracked as
   [issues](https://github.com/LumoSQL/LumoSQL/issues)
@@ -116,31 +116,30 @@ On Ubuntu 18.0.4 LTS, and on any reasonably recent Debian or Ubuntu-derived
 distribution, you need only:
 
 ```sh
-sudo apt install build-essential
+sudo apt install git build-essential
 sudo apt build-dep sqlite3
 ```
 
-( build-dep requires deb-src lines uncommented in /etc/apt/sources.list .)
+(`apt build-dep` requires `deb-src` lines uncommented in /etc/apt/sources.list).
 
 On Fedora 30, and on any reasonably recent Fedora-derived distribution:
 
 ```sh
 sudo dnf install --assumeyes \
-make gcc ncurses-devel readline-devel glibc-devel autoconf tcl-devel
+  git make gcc ncurses-devel readline-devel glibc-devel autoconf tcl-devel
 ```
 
 ## Using the Makefile tool
 
 To build either (a) specific versions of SQLite or (b) sqlightning using
-different versions of LMDB, use commands like those below:
+different versions of LMDB, use commands like those below changing the version
+numbers to suit. A list of tested version numbers is in the table below.
+
 
 ```sh
 make bld-SQLite-3.7.17
 make bld-LMDB_0.9.9
 ```
-
-changing the version numbers to suit. A list of tested version numbers is in the
-table below.
 
 # Speed tests / benchmarking
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ In the process, we noticed things that need to be fixed:
 <dd>unmodified SQLite 3.7.17, against which the 2013 changes were made. </dd>
 </dl>
 
-The benchmarking branch includes the 2013 sqlightning's cut down version of
-SQLite's `tools/speedtest.tcl` . It has been cut down to remove tests that did
-not pass with the new code but is nevertheless useful and valid:
+The benchmarking branch includes a cut down version of SQLite's
+`tools/speedtest.tcl` that passes for the 2013 sqlightning proof of concept. It
+has been cut down to remove tests that did not pass with that code but is
+nevertheless useful and valid:
 
 ```sh
 git diff orig:tool/speedtest.tcl benchmarking:tool/speedtest.tcl

--- a/tool/speedtest.tcl
+++ b/tool/speedtest.tcl
@@ -1,11 +1,28 @@
 #!/usr/bin/tclsh
 #
-# Run this script using TCLSH to do a speed comparison between
-# various versions of SQLite and PostgreSQL and MySQL
+# Run this script using TCLSH to do a speed comparison
 #
+# Originally tool/speedtest.tcl from https://sqlite.org
+#
+# Modifications copyright 2019 The LumoSQL Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2019 The LumoSQL Authors
+#
+# /tool/speedtest.tcl
 
-# Run a test
-#
 set cnt 1
 proc runtest {title} {
   global cnt


### PR DESCRIPTION
Follows on from #10 

Add Apache 2 licensing in a way that can be checked by <https://github.com/fsfe/reuse-tool>