### PR TITLE
Add tcl to build dependencies on Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ library, we use the following directory layout:
 
 ## Build environment
 
-On Ubuntu 18.0.4 LTS, and on any reasonably recent Debian or Ubuntu-derived
-distribution, you need only:
+On Ubuntu 18.0.4 LTS, Debian Stable (buster), and on any reasonably recent
+Debian or Ubuntu-derived distribution, you need only:
 
 ```sh
-sudo apt install git build-essential
+sudo apt install git build-essential tcl
 sudo apt build-dep sqlite3
 ```
 


### PR DESCRIPTION
Before this change, a bare `make` fails with an error that `tclsh` is
not installed on Debian Stable (buster). The `tcl` package is not pulled
in by the two existing steps.

After this change `tcl` is installed explicitly and the `make` command
does not exit with an error that `tclsh` is not installed.