### PR TITLE
Forked Mozilla's code of conduct / community participation guidelines.

### DIFF
--- a/doc/participation-guidelines.md
+++ b/doc/participation-guidelines.md
@@ -144,7 +144,7 @@ In addition, any participants who abuse the reporting process will be considered
 
 # Reporting
 
-If you believe you’re experiencing unacceptable behavior that will not be tolerated as outlined above please contact:  code-of-conduct@example.org .
+If you believe you’re experiencing unacceptable behavior that will not be tolerated as outlined above please contact one of the [authors](https://github.com/LumoSQL/LumoSQL/blob/master/AUTHORS).
 
 After receiving a concise description of your situation, they will review and determine next steps. In addition to conducting any investigation, they can provide a range of resources, from a private consultation to other community resources. They will involve other colleagues or outside specialists, as needed to appropriately address each situation.
 

--- a/doc/participation-guidelines.md
+++ b/doc/participation-guidelines.md
@@ -1,0 +1,156 @@
+# LumoSQL Participation Guidelines / Code of Conduct
+
+Version 1.0 – Updated February 19, 2020
+
+Adapted from version 3.1 of the 
+[LumoSQL Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
+and released under the [Creative Commons Attribution-ShareAlike](https://creativecommons.org/licenses/by-sa/3.0/)
+license. 
+
+The heart of LumoSQL is people. We put people first and do our best to recognize, appreciate and respect the diversity of our global contributors. The LumoSQL Project welcomes contributions from everyone who shares our goals and wants to contribute in a healthy and constructive manner within our community. As such, we have adopted this code of conduct and require all those who participate to agree and adhere to these Community Participation Guidelines in order to help us create a safe and positive community experience for all.
+
+These guidelines aim to support a community where all people should feel safe to participate, introduce new ideas and inspire others, regardless of:
+
+    Background
+    Family status
+    Gender
+    Gender identity or expression
+    Marital status
+    Sex
+    Sexual orientation
+    Native language
+    Age
+    Ability
+    Race and/or ethnicity
+    Caste
+    National origin
+    Socioeconomic status
+    Religion
+    Geographic location
+    Any other dimension of diversity
+
+Openness, collaboration and participation are core aspects of our work. We gain strength from diversity and actively seek participation from those who enhance it. These guidelines exist to enable diverse individuals and groups to interact and collaborate to mutual advantage. This document outlines both expected and prohibited behavior.
+
+# When and How to Use These Guidelines
+
+These guidelines outline our behavior expectations as members of the LumoSQL community in all LumoSQL activities, both offline and online. Your participation is contingent upon following these guidelines in all LumoSQL activities, including but not limited to:
+
+    * Working with other LumoSQL community participants virtually or co-located
+    * Representing LumoSQL at public events
+    * Representing LumoSQL in social media
+    * Participating in LumoSQL-related forums, mailing lists, wikis, websites, chat channels, bugs, group or person-to-person meetings, and LumoSQL-related correspondence.
+
+# Expected Behavior
+
+The following behaviors are expected of all LumoSQL community participants:
+
+## Be Respectful
+
+Value each other’s ideas, styles and viewpoints. We may not always agree, but disagreement is no excuse for poor manners. Be open to different possibilities and to being wrong. Be respectful in all interactions and communications, especially when debating the merits of different options. Be aware of your impact and how intense interactions may be affecting people. Be direct, constructive and positive. Take responsibility for your impact and your mistakes – if someone says they have been harmed through your words or actions, listen carefully, apologize sincerely, and correct the behavior going forward.
+
+## Be Direct but Professional
+
+We are likely to have some discussions about if and when criticism is respectful and when it’s not. We must be able to speak directly when we disagree and when we think we need to improve. We cannot withhold hard truths. Doing so respectfully is hard, doing so when others don’t seem to be listening is harder, and hearing such comments when one is the recipient can be even harder still. We need to be honest and direct, as well as respectful.
+
+## Be Inclusive
+
+Seek diverse perspectives. Diversity of views and of people on teams powers innovation, even if it is not always comfortable. Encourage all voices. Help new perspectives be heard and listen actively. If you find yourself dominating a discussion, it is especially important to step back and encourage other voices to join in. Be aware of how much time is taken up by dominant members of the group. Provide alternative ways to contribute or participate when possible.
+
+Be inclusive of everyone in an interaction, respecting and facilitating people’s participation whether they are:
+
+    * Remote (on video or phone)
+    * Not native language speakers
+    * Coming from a different culture
+    * Using pronouns other than “he” or “she”
+    * Living in a different time zone
+    * Facing other challenges to participate
+
+Think about how you might facilitate alternative ways to contribute or participate. If you find yourself dominating a discussion, step back. Make way for other voices and listen actively to them.
+
+## Understand Different Perspectives
+
+Our goal should not be to “win” every disagreement or argument. A more productive goal is to be open to ideas that make our own ideas better. Strive to be an example for inclusive thinking. “Winning” is when different perspectives make our work richer and stronger.
+
+## Appreciate and Accommodate Our Similarities and Differences
+
+LumoSQL community participants come from many cultures and backgrounds. Cultural differences can encompass everything from official religious observances to personal habits to clothing. Be respectful of people with different cultural practices, attitudes and beliefs. Work to eliminate your own biases, prejudices and discriminatory practices. Think of others’ needs from their point of view. Use preferred titles (including pronouns) and the appropriate tone of voice. Respect people’s right to privacy and confidentiality. Be open to learning from and educating others as well as educating yourself; it is unrealistic to expect LumoSQL community participants to know the cultural practices of every ethnic and cultural group, but everyone needs to recognize one’s native culture is only part of positive interactions.
+
+## Lead by Example
+
+By matching your actions with your words, you become a person others want to follow. Your actions influence others to behave and respond in ways that are valuable and appropriate for our organizational outcomes. Design your community and your work for inclusion. Hold yourself and others accountable for inclusive behaviors. Make decisions based on the highest good for LumoSQL’s mission.
+
+# Behavior That Will Not Be Tolerated
+
+The following behaviors are considered to be unacceptable under these guidelines.
+
+## Violence and Threats of Violence
+
+Violence and threats of violence are not acceptable - online or offline. This includes incitement of violence toward any individual, including encouraging a person to commit self-harm. This also includes posting or threatening to post other people’s personally identifying information (“doxxing”) online.
+
+## Personal Attacks
+
+Conflicts will inevitably arise, but frustration should never turn into a personal attack. It is not okay to insult, demean or belittle others. Attacking someone for their opinions, beliefs and ideas is not acceptable. It is important to speak directly when we disagree and when we think we need to improve, but such discussions must be conducted respectfully and professionally, remaining focused on the issue at hand.
+
+## Derogatory Language
+
+Hurtful or harmful language related to:
+
+    * Background
+    * Family status
+    * Gender
+    * Gender identity or expression
+    * Marital status
+    * Sex
+    * Sexual orientation
+    * Native language
+    * Age
+    * Ability
+    * Race and/or ethnicity
+    * Caste
+    * National origin
+    * Socioeconomic status
+    * Religion
+    * Geographic location
+    * Other attributes
+
+is not acceptable. This includes deliberately referring to someone by a gender that they do not identify with, and/or questioning the legitimacy of an individual’s gender identity. If you’re unsure if a word is derogatory, don’t use it. This also includes repeated subtle and/or indirect discrimination; when asked to stop, stop the behavior in question.
+
+## Unwelcome Sexual Attention or Physical Contact
+
+Unwelcome sexual attention or unwelcome physical contact is not acceptable. This includes sexualized comments, jokes or imagery in interactions, communications or presentation materials, as well as inappropriate touching, groping, or sexual advances. This includes touching a person without permission, including sensitive areas such as their hair, pregnant stomach, mobility device (wheelchair, scooter, etc) or tattoos. This also includes physically blocking or intimidating another person. Physical contact or simulated physical contact (such as emojis like “kiss”) without affirmative consent is not acceptable. This includes sharing or distribution of sexualized images or text.
+
+## Disruptive Behavior
+
+Sustained disruption of events, forums, or meetings, including talks and presentations, will not be tolerated. This includes:
+
+    * ‘Talking over’ or ‘heckling’ speakers.
+    * Drinking alcohol to excess or using recreational drugs to excess, or pushing others to do so.
+    * Making derogatory comments about those who abstain from alcohol or other substances, pushing people to drink, talking about their abstinence or preferences to others, or pressuring them to drink - physically or through jeering.
+    * Otherwise influencing crowd actions that cause hostility in the session.
+
+## Influencing Unacceptable Behavior
+
+We will treat influencing or leading such activities the same way we treat the activities themselves, and thus the same consequences apply.
+
+# Consequences of Unacceptable Behavior
+
+Bad behavior from any LumoSQL community participant, including those with decision-making authority, will not be tolerated. Intentional efforts to exclude people (except as part of a consequence of the guidelines or other official action) from LumoSQL activities are not acceptable and will be dealt with appropriately.
+
+Reports of harassment/discrimination will be promptly and thoroughly investigated by the people responsible for the safety of the space, event or activity. Appropriate measures will be taken to address the situation.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately. Violation of these guidelines can result in you being ask to leave an event or online space, either temporarily or for the duration of the event, or being banned from participation in spaces, or future events and activities in perpetuity.
+
+In addition, any participants who abuse the reporting process will be considered to be in violation of these guidelines and subject to the same consequences. False reporting, especially to retaliate or exclude, will not be accepted or tolerated.
+
+# Reporting
+
+If you believe you’re experiencing unacceptable behavior that will not be tolerated as outlined above please contact:  code-of-conduct@example.org .
+
+After receiving a concise description of your situation, they will review and determine next steps. In addition to conducting any investigation, they can provide a range of resources, from a private consultation to other community resources. They will involve other colleagues or outside specialists, as needed to appropriately address each situation.
+
+Please also report to us if you observe a potentially dangerous situation, someone in distress, or violations of these guidelines, even if the situation is not happening to you.
+
+If you feel you have been unfairly accused of violating these guidelines, please follow the same reporting process.
+
+
+

--- a/doc/participation-guidelines.md
+++ b/doc/participation-guidelines.md
@@ -3,7 +3,7 @@
 Version 1.0 – Updated February 19, 2020
 
 Adapted from version 3.1 of the 
-[LumoSQL Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
+[Mozilla Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
 and released under the [Creative Commons Attribution-ShareAlike](https://creativecommons.org/licenses/by-sa/3.0/)
 license. 
 
@@ -151,6 +151,5 @@ After receiving a concise description of your situation, they will review and de
 Please also report to us if you observe a potentially dangerous situation, someone in distress, or violations of these guidelines, even if the situation is not happening to you.
 
 If you feel you have been unfairly accused of violating these guidelines, please follow the same reporting process.
-
 
 

--- a/doc/participation-guidelines.md
+++ b/doc/participation-guidelines.md
@@ -11,7 +11,7 @@ The heart of LumoSQL is people. We put people first and do our best to recognize
 
 These guidelines aim to support a community where all people should feel safe to participate, introduce new ideas and inspire others, regardless of:
 
-    Background
+- Background
     Family status
     Gender
     Gender identity or expression
@@ -151,5 +151,4 @@ After receiving a concise description of your situation, they will review and de
 Please also report to us if you observe a potentially dangerous situation, someone in distress, or violations of these guidelines, even if the situation is not happening to you.
 
 If you feel you have been unfairly accused of violating these guidelines, please follow the same reporting process.
-
 

--- a/doc/participation-guidelines.md
+++ b/doc/participation-guidelines.md
@@ -4,7 +4,7 @@ Version 1.0 – Updated February 19, 2020
 
 Adapted from version 3.1 of the 
 [Mozilla Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
-and released under the [Creative Commons Attribution-ShareAlike](https://creativecommons.org/licenses/by-sa/3.0/)
+and released under the [Creative Commons Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)
 license. 
 
 The heart of LumoSQL is people. We put people first and do our best to recognize, appreciate and respect the diversity of our global contributors. The LumoSQL Project welcomes contributions from everyone who shares our goals and wants to contribute in a healthy and constructive manner within our community. As such, we have adopted this code of conduct and require all those who participate to agree and adhere to these Community Participation Guidelines in order to help us create a safe and positive community experience for all.
@@ -151,4 +151,3 @@ After receiving a concise description of your situation, they will review and de
 Please also report to us if you observe a potentially dangerous situation, someone in distress, or violations of these guidelines, even if the situation is not happening to you.
 
 If you feel you have been unfairly accused of violating these guidelines, please follow the same reporting process.
-


### PR DESCRIPTION
Converted to markdown. Deleted irrelevant items (Mozilla is thousands of times
larger than LumoSQL, and also has employees.) The reporting email address is
set to example.org for now. I think it can be committed as-is.