### PR TITLE
Fixed link on lumo-quickstart.html

### DIFF
--- a/doc/www/lumo-quickstart.md
+++ b/doc/www/lumo-quickstart.md
@@ -50,7 +50,7 @@ SQLite without forking it, although there are other goals as well.
 
 LumoSQL is supported by the [NLNet Foundation](https://nlnet.nl).
 
-If you are interesting in contributing to LumoSQL please see [CONTRIBUTING](/CONTRIBUTING.md).
+If you are interesting in contributing to LumoSQL please see [CONTRIBUTING](https://github.com/LumoSQL/LumoSQL/blob/master/CONTRIBUTING.md).
 
 
 


### PR DESCRIPTION
On the page https://lumosql.github.io/lumo-quickstart.html is a broken link for CONTRIBUTING.md file. This pull request replaces it with direct link that works in GitHub documentation and web site. 

